### PR TITLE
Remove the box link on the home page for video tutorials

### DIFF
--- a/gnome-help/C/endless-videos.page
+++ b/gnome-help/C/endless-videos.page
@@ -6,7 +6,6 @@
       type="guide" style="task" id="endless-videos" version="1.0 if/1.0">
 
 <info>
-    <link type="guide" xref="index" group="#first"/>
     <desc>Watch videos explaining how to use EndlessOS.</desc>
     <title type='link'>Videos Tutorials</title>
     <title type='sort'>Videos Tutorials</title>


### PR DESCRIPTION
We now have the video thumbnails and the "More..." link. So its not
mainly redundant
[endlessm/eos-shell#4073]
