### PR TITLE
Fix up attributions for getting started docs

### DIFF
--- a/gnome-help/C/endless-01-desktop.page
+++ b/gnome-help/C/endless-01-desktop.page
@@ -6,6 +6,16 @@
       type="guide" style="task" id="endless-01-desktop" version="1.0 if/1.0">
 <info>
     <link type="guide" xref="endless-videos" group="#videos"/>
+
+    <credit type="author">
+      <name>Nuritzi Sanchez</name>
+    </credit>
+
+    <credit type="copyright">
+      <name>Endless Mobile, Inc.</name>
+      <years>2014</years>
+    </credit>
+
     <title type='link'>Introduction to the desktop</title>
     <title type='sort'>01</title>
     <desc>A video showing the basics of the Endless desktop.</desc>

--- a/gnome-help/C/endless-02-folders.page
+++ b/gnome-help/C/endless-02-folders.page
@@ -6,6 +6,16 @@
       type="guide" style="task" id="endless-02-folders" version="1.0 if/1.0">
 <info>
     <link type="guide" xref="endless-videos" group="#videos"/>
+
+    <credit type="author">
+      <name>Nuritzi Sanchez</name>
+    </credit>
+
+    <credit type="copyright">
+      <name>Endless Mobile, Inc.</name>
+      <years>2014</years>
+    </credit>
+
     <title type='link'>Adding folders to the desktop</title>
     <title type='sort'>02</title>
     <desc>A video showing how to add a folder to the desktop.</desc>

--- a/gnome-help/C/endless-03-programs.page
+++ b/gnome-help/C/endless-03-programs.page
@@ -6,6 +6,16 @@
       type="guide" style="task" id="endless-03-programs" version="1.0 if/1.0">
 <info>
     <link type="guide" xref="endless-videos" group="#videos"/>
+
+    <credit type="author">
+      <name>Nuritzi Sanchez</name>
+    </credit>
+
+    <credit type="copyright">
+      <name>Endless Mobile, Inc.</name>
+      <years>2014</years>
+    </credit>
+
     <title type='link'>Installing programs</title>
     <title type='sort'>03</title>
     <desc>A video showing how to install programs.</desc>

--- a/gnome-help/C/endless-04-wifi.page
+++ b/gnome-help/C/endless-04-wifi.page
@@ -6,6 +6,16 @@
       type="guide" style="task" id="endless-04-wifi" version="1.0 if/1.0">
 <info>
     <link type="guide" xref="endless-videos" group="#videos"/>
+
+    <credit type="author">
+      <name>Nuritzi Sanchez</name>
+    </credit>
+
+    <credit type="copyright">
+      <name>Endless Mobile, Inc.</name>
+      <years>2014</years>
+    </credit>
+
     <title type='link'>Using Wi-Fi</title>
     <title type='sort'>04</title>
     <desc>A video showing how to set up Wi-Fi with Endless.</desc>

--- a/gnome-help/C/endless-05-files.page
+++ b/gnome-help/C/endless-05-files.page
@@ -6,6 +6,16 @@
       type="guide" style="task" id="endless-05-files" version="1.0 if/1.0">
 <info>
     <link type="guide" xref="endless-videos" group="#videos"/>
+
+    <credit type="author">
+      <name>Nuritzi Sanchez</name>
+    </credit>
+
+    <credit type="copyright">
+      <name>Endless Mobile, Inc.</name>
+      <years>2014</years>
+    </credit>
+
     <title type='link'>Exploring your files</title>
     <title type='sort'>05</title>
     <desc>A video showing how to use the file system.</desc>

--- a/gnome-help/C/endless-06-browser.page
+++ b/gnome-help/C/endless-06-browser.page
@@ -6,6 +6,16 @@
       type="guide" style="task" id="endless-06-browser" version="1.0 if/1.0">
 <info>
     <link type="guide" xref="endless-videos" group="#videos"/>
+
+    <credit type="author">
+      <name>Nuritzi Sanchez</name>
+    </credit>
+
+    <credit type="copyright">
+      <name>Endless Mobile, Inc.</name>
+      <years>2014</years>
+    </credit>
+
     <title type='link'>Browsing the Internet</title>
     <title type='sort'>06</title>
     <desc>A video explaining how to user browse web pages.</desc>

--- a/gnome-help/C/endless-07-windows.page
+++ b/gnome-help/C/endless-07-windows.page
@@ -6,6 +6,16 @@
       type="guide" style="task" id="endless-07-windows" version="1.0 if/1.0">
 <info>
     <link type="guide" xref="endless-videos" group="#videos"/>
+
+    <credit type="author">
+      <name>Nuritzi Sanchez</name>
+    </credit>
+
+    <credit type="copyright">
+      <name>Endless Mobile, Inc.</name>
+      <years>2014</years>
+    </credit>
+
     <title type='link'>Minimizing and closing windows</title>
     <title type='sort'>07</title>
     <desc>A video showing how to minimize and close your windows.</desc>

--- a/gnome-help/C/endless-08-offline.page
+++ b/gnome-help/C/endless-08-offline.page
@@ -6,6 +6,16 @@
       type="guide" style="task" id="endless-08-offline" version="1.0 if/1.0">
 <info>
     <link type="guide" xref="endless-videos" group="#videos"/>
+
+    <credit type="author">
+      <name>Nuritzi Sanchez</name>
+    </credit>
+
+    <credit type="copyright">
+      <name>Endless Mobile, Inc.</name>
+      <years>2014</years>
+    </credit>
+
     <title type='link'>Using Endless offline</title>
     <title type='sort'>08</title>
     <desc>A video showing the offline content on your computer.</desc>

--- a/gnome-help/C/endless-09-writer.page
+++ b/gnome-help/C/endless-09-writer.page
@@ -6,6 +6,16 @@
       type="guide" style="task" id="endless-09-writer" version="1.0 if/1.0">
 <info>
     <link type="guide" xref="endless-videos" group="#videos"/>
+
+    <credit type="author">
+      <name>Nuritzi Sanchez</name>
+    </credit>
+
+    <credit type="copyright">
+      <name>Endless Mobile, Inc.</name>
+      <years>2014</years>
+    </credit>
+
     <title type='link'>Using the Writer program</title>
     <title type='sort'>09</title>
     <desc>A video showing how to use the Writer to create documents.</desc>

--- a/gnome-help/C/endless-10-video-player.page
+++ b/gnome-help/C/endless-10-video-player.page
@@ -6,6 +6,16 @@
       type="guide" style="task" id="endless-10-video-player" version="1.0 if/1.0">
 <info>
     <link type="guide" xref="endless-videos" group="#videos"/>
+
+    <credit type="author">
+      <name>Nuritzi Sanchez</name>
+    </credit>
+
+    <credit type="copyright">
+      <name>Endless Mobile, Inc.</name>
+      <years>2014</years>
+    </credit>
+
     <title type='link'>Playing videos</title>
     <title type='sort'>10</title>
     <desc>A video showing how to play movies and videos with Endless.</desc>

--- a/gnome-help/C/endless-11-photos-and-music.page
+++ b/gnome-help/C/endless-11-photos-and-music.page
@@ -6,6 +6,16 @@
       type="guide" style="task" id="endless-11-photos-and-music" version="1.0 if/1.0">
 <info>
     <link type="guide" xref="endless-videos" group="#videos"/>
+
+    <credit type="author">
+      <name>Nuritzi Sanchez</name>
+    </credit>
+
+    <credit type="copyright">
+      <name>Endless Mobile, Inc.</name>
+      <years>2014</years>
+    </credit>
+
     <title type='link'>Photos and Music</title>
     <title type='sort'>11</title>
     <desc>A video showing how to edit photos and listen to music.</desc>

--- a/gnome-help/C/endless-12-social-bar.page
+++ b/gnome-help/C/endless-12-social-bar.page
@@ -6,6 +6,16 @@
       type="guide" style="task" id="endless-12-social-bar" version="1.0 if/1.0">
 <info>
     <link type="guide" xref="endless-videos" group="#videos"/>
+
+    <credit type="author">
+      <name>Nuritzi Sanchez</name>
+    </credit>
+
+    <credit type="copyright">
+      <name>Endless Mobile, Inc.</name>
+      <years>2014</years>
+    </credit>
+
     <title type='link'>Using Facebook</title>
     <title type='sort'>12</title>
     <desc>A video showing how to use Facebook with other programs.</desc>

--- a/gnome-help/C/gs-add-new-app.page
+++ b/gnome-help/C/gs-add-new-app.page
@@ -4,9 +4,13 @@
       type="topic" style="ui" id="gs-add-new-app">
 
   <info>
-    <include href="gs-legal.xml" xmlns="http://www.w3.org/2001/XInclude"/>
     <credit type="author">
       <name>Nuritzi Sanchez</name>
+    </credit>
+
+    <credit type="copyright">
+      <name>Endless Mobile, Inc.</name>
+      <years>2014</years>
     </credit>
 
     <link type="guide" xref="index"/>

--- a/gnome-help/C/gs-add-user-accounts.page
+++ b/gnome-help/C/gs-add-user-accounts.page
@@ -4,9 +4,13 @@
       type="topic" style="ui" id="gs-add-user-accounts">
 
   <info>
-    <include href="gs-legal.xml" xmlns="http://www.w3.org/2001/XInclude"/>
     <credit type="author">
       <name>Nuritzi Sanchez</name>
+    </credit>
+
+    <credit type="copyright">
+      <name>Endless Mobile, Inc.</name>
+      <years>2014</years>
     </credit>
 
     <link type="guide" xref="index"/>

--- a/gnome-help/C/gs-browse-web.page
+++ b/gnome-help/C/gs-browse-web.page
@@ -11,6 +11,9 @@
     <credit type="author">
       <name>Petr Kovar</name>
     </credit>
+    <credit type="author">
+      <name>Nuritzi Sanchez</name>
+    </credit>
 
     <link type="guide" xref="net#browser"/>
   </info>

--- a/gnome-help/C/gs-connect-online-accounts.page
+++ b/gnome-help/C/gs-connect-online-accounts.page
@@ -11,6 +11,9 @@
     <credit type="author">
       <name>Petr Kovar</name>
     </credit>
+    <credit type="author">
+      <name>Nuritzi Sanchez</name>
+    </credit>
 
     <link type="guide" xref="net#social"/>
   </info>

--- a/gnome-help/C/gs-fix-overscan.page
+++ b/gnome-help/C/gs-fix-overscan.page
@@ -4,9 +4,13 @@
       type="topic" style="ui" id="gs-fix-overscan">
 
   <info>
-    <include href="gs-legal.xml" xmlns="http://www.w3.org/2001/XInclude"/>
     <credit type="author">
       <name>Nuritzi Sanchez</name>
+    </credit>
+
+    <credit type="copyright">
+      <name>Endless Mobile, Inc.</name>
+      <years>2014</years>
     </credit>
 
     <link type="guide" xref="index"/>

--- a/gnome-help/C/gs-get-online.page
+++ b/gnome-help/C/gs-get-online.page
@@ -11,6 +11,9 @@
     <credit type="author">
       <name>Petr Kovar</name>
     </credit>
+    <credit type="author">
+      <name>Nuritzi Sanchez</name>
+    </credit>
 
     <link type="guide" xref="index"/>
   </info>

--- a/gnome-help/C/gs-give-feedback.page
+++ b/gnome-help/C/gs-give-feedback.page
@@ -4,9 +4,13 @@
       type="topic" style="ui" id="gs-give-feedback">
 
   <info>
-    <include href="gs-legal.xml" xmlns="http://www.w3.org/2001/XInclude"/>
     <credit type="author">
       <name>Nuritzi Sanchez</name>
+    </credit>
+
+    <credit type="copyright">
+      <name>Endless Mobile, Inc.</name>
+      <years>2014</years>
     </credit>
 
     <link type="guide" xref="index"/>

--- a/gnome-help/C/gs-set-up-printer.page
+++ b/gnome-help/C/gs-set-up-printer.page
@@ -4,9 +4,13 @@
       type="topic" style="ui" id="gs-set-up-printer">
 
   <info>
-    <include href="gs-legal.xml" xmlns="http://www.w3.org/2001/XInclude"/>
     <credit type="author">
       <name>Nuritzi Sanchez</name>
+    </credit>
+
+    <credit type="copyright">
+      <name>Endless Mobile, Inc.</name>
+      <years>2014</years>
     </credit>
 
     <link type="guide" xref="index"/>

--- a/gnome-help/C/gs-use-offline.page
+++ b/gnome-help/C/gs-use-offline.page
@@ -4,9 +4,13 @@
       type="topic" style="ui" id="gs-use-offline">
 
   <info>
-    <include href="gs-legal.xml" xmlns="http://www.w3.org/2001/XInclude"/>
     <credit type="author">
       <name>Nuritzi Sanchez</name>
+    </credit>
+
+    <credit type="copyright">
+      <name>Endless Mobile, Inc.</name>
+      <years>2014</years>
     </credit>
 
     <link type="guide" xref="index"/>

--- a/gnome-help/C/gs-use-system-search.page
+++ b/gnome-help/C/gs-use-system-search.page
@@ -11,6 +11,9 @@
     <credit type="author">
       <name>Petr Kovar</name>
     </credit>
+    <credit type="author">
+      <name>Nuritzi Sanchez</name>
+    </credit>
 
     <link type="guide" xref="shell-overview#search"/>
   </info>

--- a/gnome-help/C/gs-where-files.page
+++ b/gnome-help/C/gs-where-files.page
@@ -4,9 +4,13 @@
       type="topic" style="ui" id="gs-where-files">
 
   <info>
-    <include href="gs-legal.xml" xmlns="http://www.w3.org/2001/XInclude"/>
     <credit type="author">
       <name>Nuritzi Sanchez</name>
+    </credit>
+
+    <credit type="copyright">
+      <name>Endless Mobile, Inc.</name>
+      <years>2014</years>
     </credit>
 
     <link type="guide" xref="index"/>


### PR DESCRIPTION
For pages only written by Nuritzi, we remove the CC-BY-SA license
put an endless copyright notice and list her as only author.

For gnome pages we have contributed too, just add Nuritzi as author
[endlessm/eos-shell#3977]
